### PR TITLE
Remove leading space before php tag in routes/web.php

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -1,4 +1,3 @@
-
 <?php
 
 use Illuminate\Support\Facades\Route;


### PR DESCRIPTION
After a lot of digging, I finally found the culprit.  For now I'm using `TwilioVerify::ignoreRoutes()` and adding the routes manually, but I'd rather use the included routes for simplicity.

Thanks for putting this together, it works great.